### PR TITLE
Pull unreviewed translations

### DIFF
--- a/update-and-commit-translations.sh
+++ b/update-and-commit-translations.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 set -x
 
-tx pull -f -a --minimum-perc=1 --traceback
+tx --traceback pull -f -a --minimum-perc=1
 
 git update-index -q --refresh
 

--- a/update-and-commit-translations.sh
+++ b/update-and-commit-translations.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 set -x
 
-tx pull -f --mode=reviewed
+tx pull -f -a --minimum-perc=1 --traceback
 
 git update-index -q --refresh
 


### PR DESCRIPTION
Also automatically add translations for languages once they start being translated in Transifex. Also produce useful error messages when failing.