### PR TITLE
Allow setting the repository name, to support repos other than 'openmrs/openmrs-module-XYZ'

### DIFF
--- a/update-and-commit-translations.sh
+++ b/update-and-commit-translations.sh
@@ -11,7 +11,8 @@ git update-index -q --refresh
 
 # If running inside a Bamboo agent, set git origin
 if [ -n "${bamboo_shortJobName}" ]; then
-  remote_url="git@github.com:openmrs/openmrs-module-${bamboo_shortJobName}.git"
+  resolved_repo_name=${REPO_NAME:-openmrs/openmrs-module-$bamboo_shortJobName}
+  remote_url="git@github.com:${resolved_repo_name}.git"
   echo "Setting git remote to ${remote_url}"
   git remote set-url origin $remote_url
 fi


### PR DESCRIPTION
This is so we can replace this failing action in owa-orderentry: https://github.com/openmrs/openmrs-owa-orderentry/actions/runs/1406104412